### PR TITLE
checking for headers before trying to set on them

### DIFF
--- a/email.go
+++ b/email.go
@@ -89,6 +89,10 @@ func (e *Email) Bytes() ([]byte, error) {
 	w := multipart.NewWriter(buff)
 	// Set the appropriate headers (overwriting any conflicts)
 	// Leave out Bcc (only included in envelope headers)
+	if e.Headers == nil {
+		e.Headers = textproto.MIMEHeader{}
+	}
+
 	e.Headers.Set("To", strings.Join(e.To, ","))
 	if e.Cc != nil {
 		e.Headers.Set("Cc", strings.Join(e.Cc, ","))


### PR DESCRIPTION
As a personal preference I like to use the struct literal method to initialize and this avoids having to include the net/textproto package and set this bit of boilerplate if I don't need to.
