### PR TITLE
Add alternative only

### DIFF
--- a/email.go
+++ b/email.go
@@ -242,7 +242,7 @@ func (e *Email) AttachFile(filename string) (a *Attachment, err error) {
 func (e *Email) msgHeaders() (textproto.MIMEHeader, error) {
 	res := make(textproto.MIMEHeader, len(e.Headers)+4)
 	if e.Headers != nil {
-		for _, h := range []string{"To", "Cc", "From", "Subject", "Date", "Message-Id"} {
+		for _, h := range []string{"To", "Cc", "From", "Subject", "Date", "Message-Id", "MIME-Version"} {
 			if v, ok := e.Headers[h]; ok {
 				res[h] = v
 			}
@@ -272,8 +272,8 @@ func (e *Email) msgHeaders() (textproto.MIMEHeader, error) {
 	if _, ok := res["Date"]; !ok {
 		res.Set("Date", time.Now().Format(time.RFC1123Z))
 	}
-	if _, ok := res["Mime-Version"]; !ok {
-		res.Set("Mime-Version", "1.0")
+	if _, ok := res["MIME-Version"]; !ok {
+		res.Set("MIME-Version", "1.0")
 	}
 	for field, vals := range e.Headers {
 		if _, ok := res[field]; !ok {

--- a/email.go
+++ b/email.go
@@ -321,13 +321,14 @@ func (e *Email) Bytes() ([]byte, error) {
 	if isMixed || isAlternative {
 		w = multipart.NewWriter(buff)
 	}
-	if isMixed {
+	switch {
+	case isMixed:
 		headers.Set("Content-Type", "multipart/mixed;\r\n boundary="+w.Boundary())
-	} else if isAlternative {
+	case isAlternative:
 		headers.Set("Content-Type", "multipart/alternative;\r\n boundary="+w.Boundary())
-	} else if len(e.HTML) > 0 {
+	case len(e.HTML) > 0:
 		headers.Set("Content-Type", "text/html; charset=UTF-8")
-	} else {
+	default:
 		headers.Set("Content-Type", "text/plain; charset=UTF-8")
 	}
 	headerToBytes(buff, headers)

--- a/email_test.go
+++ b/email_test.go
@@ -15,17 +15,17 @@ import (
 	"net/textproto"
 )
 
-func TestEmailTextHtmlAttachment(t *testing.T) {
+func prepareEmail() *Email {
 	e := NewEmail()
 	e.From = "Jordan Wright <test@example.com>"
 	e.To = []string{"test@example.com"}
 	e.Bcc = []string{"test_bcc@example.com"}
 	e.Cc = []string{"test_cc@example.com"}
 	e.Subject = "Awesome Subject"
-	e.Text = []byte("Text Body is, of course, supported!\n")
-	e.HTML = []byte("<h1>Fancy Html is supported, too!</h1>\n")
-	e.Attach(bytes.NewBufferString("Rad attachement"), "rad.txt", "text/plain; charset=utf-8")
+	return e
+}
 
+func basicTests(t *testing.T, e *Email) *mail.Message {
 	raw, err := e.Bytes()
 	if err != nil {
 		t.Fatal("Failed to render message: ", e)
@@ -48,6 +48,111 @@ func TestEmailTextHtmlAttachment(t *testing.T) {
 			t.Errorf("Wrong value for message header %s: %v != %v", header, expected, val)
 		}
 	}
+	return msg
+}
+
+func TestEmailText(t *testing.T) {
+	e := prepareEmail()
+	e.Text = []byte("Text Body is, of course, supported!\n")
+
+	msg := basicTests(t, e)
+
+	// Were the right headers set?
+	ct := msg.Header.Get("Content-type")
+	mt, _, err := mime.ParseMediaType(ct)
+	if err != nil {
+		t.Fatal("Content-type header is invalid: ", ct)
+	} else if mt != "text/plain" {
+		t.Fatalf("Content-type expected \"text/plain\", not %v", mt)
+	}
+}
+
+func TestEmailHTML(t *testing.T) {
+	e := prepareEmail()
+	e.HTML = []byte("<h1>Fancy Html is supported, too!</h1>\n")
+
+	msg := basicTests(t, e)
+
+	// Were the right headers set?
+	ct := msg.Header.Get("Content-type")
+	mt, _, err := mime.ParseMediaType(ct)
+	if err != nil {
+		t.Fatal("Content-type header is invalid: ", ct)
+	} else if mt != "text/html" {
+		t.Fatalf("Content-type expected \"text/html\", not %v", mt)
+	}
+}
+
+func TestEmailTextAttachment(t *testing.T) {
+	e := prepareEmail()
+	e.Text = []byte("Text Body is, of course, supported!\n")
+	_, err := e.Attach(bytes.NewBufferString("Rad attachment"), "rad.txt", "text/plain; charset=utf-8")
+	if err != nil {
+		t.Fatal("Could not add an attachment to the message: ", err)
+	}
+
+	msg := basicTests(t, e)
+
+	// Were the right headers set?
+	ct := msg.Header.Get("Content-type")
+	mt, params, err := mime.ParseMediaType(ct)
+	if err != nil {
+		t.Fatal("Content-type header is invalid: ", ct)
+	} else if mt != "multipart/mixed" {
+		t.Fatalf("Content-type expected \"multipart/mixed\", not %v", mt)
+	}
+	b := params["boundary"]
+	if b == "" {
+		t.Fatalf("Invalid or missing boundary parameter: ", b)
+	}
+	if len(params) != 1 {
+		t.Fatal("Unexpected content-type parameters")
+	}
+
+	// Is the generated message parsable?
+	mixed := multipart.NewReader(msg.Body, params["boundary"])
+
+	text, err := mixed.NextPart()
+	if err != nil {
+		t.Fatalf("Could not find text component of email: ", err)
+	}
+
+	// Does the text portion match what we expect?
+	mt, _, err = mime.ParseMediaType(text.Header.Get("Content-type"))
+	if err != nil {
+		t.Fatal("Could not parse message's Content-Type")
+	} else if mt != "text/plain" {
+		t.Fatal("Message missing text/plain")
+	}
+	plainText, err := ioutil.ReadAll(text)
+	if err != nil {
+		t.Fatal("Could not read plain text component of message: ", err)
+	}
+	if !bytes.Equal(plainText, []byte("Text Body is, of course, supported!\r\n")) {
+		t.Fatalf("Plain text is broken: %#q", plainText)
+	}
+
+	// Check attachments.
+	_, err = mixed.NextPart()
+	if err != nil {
+		t.Fatalf("Could not find attachment component of email: ", err)
+	}
+
+	if _, err = mixed.NextPart(); err != io.EOF {
+		t.Error("Expected only text and one attachment!")
+	}
+}
+
+func TestEmailTextHtmlAttachment(t *testing.T) {
+	e := prepareEmail()
+	e.Text = []byte("Text Body is, of course, supported!\n")
+	e.HTML = []byte("<h1>Fancy Html is supported, too!</h1>\n")
+	_, err := e.Attach(bytes.NewBufferString("Rad attachment"), "rad.txt", "text/plain; charset=utf-8")
+	if err != nil {
+		t.Fatal("Could not add an attachment to the message: ", err)
+	}
+
+	msg := basicTests(t, e)
 
 	// Were the right headers set?
 	ct := msg.Header.Get("Content-type")
@@ -96,13 +201,50 @@ func TestEmailTextHtmlAttachment(t *testing.T) {
 	// Check attachments.
 	_, err = mixed.NextPart()
 	if err != nil {
-		t.Fatalf("Could not find attachemnt compoenent of email: ", err)
+		t.Fatalf("Could not find attachment component of email: ", err)
 	}
 
 	if _, err = mixed.NextPart(); err != io.EOF {
-		t.Error("Expected only text and one attachement!")
+		t.Error("Expected only text and one attachment!")
+	}
+}
+
+func TestEmailAttachment(t *testing.T) {
+	e := prepareEmail()
+	_, err := e.Attach(bytes.NewBufferString("Rad attachment"), "rad.txt", "text/plain; charset=utf-8")
+	if err != nil {
+		t.Fatal("Could not add an attachment to the message: ", err)
+	}
+	msg := basicTests(t, e)
+
+	// Were the right headers set?
+	ct := msg.Header.Get("Content-type")
+	mt, params, err := mime.ParseMediaType(ct)
+	if err != nil {
+		t.Fatal("Content-type header is invalid: ", ct)
+	} else if mt != "multipart/mixed" {
+		t.Fatalf("Content-type expected \"multipart/mixed\", not %v", mt)
+	}
+	b := params["boundary"]
+	if b == "" {
+		t.Fatalf("Invalid or missing boundary parameter: ", b)
+	}
+	if len(params) != 1 {
+		t.Fatal("Unexpected content-type parameters")
 	}
 
+	// Is the generated message parsable?
+	mixed := multipart.NewReader(msg.Body, params["boundary"])
+
+	// Check attachments.
+	_, err = mixed.NextPart()
+	if err != nil {
+		t.Fatalf("Could not find attachment component of email: ", err)
+	}
+
+	if _, err = mixed.NextPart(); err != io.EOF {
+		t.Error("Expected only one attachment!")
+	}
 }
 
 func TestEmailFromReader(t *testing.T) {


### PR DESCRIPTION
`Bytes()` tries to optimize the parts created:
1. no mixed for a text or html message
2. no alternate for a text or html message with attachments

Special handling, if any, or an email consisting of a sole attachment hasn’t been added.

Test cases have been added to cover the different cases.