### PR TITLE
Minor change to make the source more go idiomatic

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -80,9 +80,7 @@ func (p *Pool) get(timeout time.Duration) *client {
 	}
 
 	var deadline <-chan time.Time
-	if timeout < 0 {
-		deadline = nil
-	} else {
+	if timeout >= 0 {
 		deadline = time.After(timeout)
 	}
 


### PR DESCRIPTION
Minor change to make the code more Go idiomatic, not needing to assign
nil to a channel which is just declared, because its default it's nil.