### PR TITLE
Named attachements

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ e := NewEmail()
 e.AttachFile("test.txt")
 ```
 
+#### Attaching a File with custom file name
+```go
+e := NewEmail()
+e.AttachFileWithName("internalName.txt", "publicName.txt")
+```
+
 #### A Pool of Reusable Connections
 ```go
 (var ch <-chan *email.Email)

--- a/email.go
+++ b/email.go
@@ -246,6 +246,21 @@ func (e *Email) AttachFile(filename string) (a *Attachment, err error) {
 	return e.Attach(f, basename, ct)
 }
 
+// AttachFileWithName is used to attach content to the email.
+// It attempts to open the file referenced by filePath and, if successful, creates an Attachment with the provided fileName.
+// This Attachment is then appended to the slice of Email.Attachments.
+// The function will then return the Attachment for reference, as well as nil for the error, if successful.
+func (e *Email) AttachFileWithName(filePath, fileName string) (a *Attachment, err error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	ct := mime.TypeByExtension(filepath.Ext(filePath))
+	return e.Attach(f, fileName, ct)
+}
+
 // msgHeaders merges the Email's various fields and custom headers together in a
 // standards compliant way to create a MIMEHeader to be used in the resulting
 // message. It does not alter e.Headers.


### PR DESCRIPTION
Add the ability to attach a file with a custom file name
Instead of using the default:
```go
e := NewEmail()
e.AttachFile("test.txt")
```
you can provide a custom named file using this:
```go
e := NewEmail()
e.AttachFileWithName("internalName.txt", "publicName.txt")
```