### PR TITLE
trimReader will only trim on the very first Read

### DIFF
--- a/email.go
+++ b/email.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 )
@@ -68,13 +69,17 @@ func NewEmail() *Email {
 // whitespace, as this can cause email imports to fail.
 type trimReader struct {
 	rd io.Reader
+	trimOnce sync.Once
 }
 
-// Read trims off any unicode whitespace from the originating reader
-func (tr trimReader) Read(buf []byte) (int, error) {
+// Read trims off any unicode whitespace from the originating reader.
+// Only trims on the very first read.
+func (tr *trimReader) Read(buf []byte) (int, error) {
 	n, err := tr.rd.Read(buf)
-	t := bytes.TrimLeftFunc(buf[:n], unicode.IsSpace)
-	n = copy(buf, t)
+	tr.trimOnce.Do(func() {
+		t := bytes.TrimLeftFunc(buf[:n], unicode.IsSpace)
+		n = copy(buf, t)
+	})
 	return n, err
 }
 
@@ -84,7 +89,7 @@ func (tr trimReader) Read(buf []byte) (int, error) {
 func NewEmailFromReader(r io.Reader) (*Email, error) {
 	e := NewEmail()
 	s := trimReader{rd: r}
-	tp := textproto.NewReader(bufio.NewReader(s))
+	tp := textproto.NewReader(bufio.NewReader(&s))
 	// Parse the main headers
 	hdrs, err := tp.ReadMIMEHeader()
 	if err != nil {


### PR DESCRIPTION
At present trimReader will trim leading white space on every Read. As a result if the second or subsequent reads start with white space then this white space is trimmed despite being part of the emails content.

Added test with a large text body consisting only of spaces, body is large enough to ensure that the second read of trimReader will start with spaces from the body at the beginning of the buffer. Without this fix the test will fail as the text body has been truncated.