### PR TITLE
chore(go-mod): stick to Go 1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/jordan-wright/email
+
+go 1.13


### PR DESCRIPTION
This was automagically added by Go when I coded up [1]. Not sure it's needed.

[1] https://github.com/jordan-wright/email/pull/93