### PR TITLE
Add pool.SetHelloHostname() to override SMTP HELO hostname (FQDN)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/jordan-wright/email
+
+go 1.13


### PR DESCRIPTION
By default, Go's smtp lib uses "localhost" when issuing a HELO to SMTP servers (See https://github.com/mailhog/MailHog/issues/257). Some SMTP servers reject this demanding an FQDN instead.

This PR adds a new method `pool.SetHelloHostname()` that instructs smtp.Client to use a custom hostname.