### PR TITLE
Format From, To, Cc & Bcc for RFC1342

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+
+# IDEs
+.idea

--- a/email.go
+++ b/email.go
@@ -641,6 +641,18 @@ func headerToBytes(buff io.Writer, header textproto.MIMEHeader) {
 			switch {
 			case field == "Content-Type" || field == "Content-Disposition":
 				buff.Write([]byte(subval))
+			case field == "From" || field == "To" || field == "Cc" || field == "Bcc":
+				participants := strings.Split(subval, ";")
+				for i, v := range participants {
+					addr, err := mail.ParseAddress(v)
+					if err != nil {
+						continue
+					}
+					if addr.Name != "" {
+						participants[i] = fmt.Sprintf("%s <%s>", mime.QEncoding.Encode("UTF-8", addr.Name), addr.Address)
+					}
+				}
+				buff.Write([]byte(strings.Join(participants, ";")))
 			default:
 				buff.Write([]byte(mime.QEncoding.Encode("UTF-8", subval)))
 			}

--- a/email.go
+++ b/email.go
@@ -642,7 +642,7 @@ func headerToBytes(buff io.Writer, header textproto.MIMEHeader) {
 			case field == "Content-Type" || field == "Content-Disposition":
 				buff.Write([]byte(subval))
 			case field == "From" || field == "To" || field == "Cc" || field == "Bcc":
-				participants := strings.Split(subval, ";")
+				participants := strings.Split(subval, ",")
 				for i, v := range participants {
 					addr, err := mail.ParseAddress(v)
 					if err != nil {
@@ -652,7 +652,7 @@ func headerToBytes(buff io.Writer, header textproto.MIMEHeader) {
 						participants[i] = fmt.Sprintf("%s <%s>", mime.QEncoding.Encode("UTF-8", addr.Name), addr.Address)
 					}
 				}
-				buff.Write([]byte(strings.Join(participants, ";")))
+				buff.Write([]byte(strings.Join(participants, ", ")))
 			default:
 				buff.Write([]byte(mime.QEncoding.Encode("UTF-8", subval)))
 			}


### PR DESCRIPTION
EMails needed to be formated like this:
```
   From: =?US-ASCII?Q?Keith_Moore?= <moore@cs.utk.edu>
   To: =?ISO-8859-1?Q?Keld_J=F8rn_Simonsen?= <keld@dkuug.dk>
   CC: =?ISO-8859-1?Q?Andr=E9_?= Pirard <PIRARD@vm1.ulg.ac.be>
```

Right now the complete content of the field will be encoded which results in
```
   From: =?US-ASCII?Q?Keith_Moore <moore@cs.utk.edu>?=
   To: =?ISO-8859-1?Q?Keld_J=F8rn_Simonsen <keld@dkuug.dk>?=
   CC: =?ISO-8859-1?Q?Andr=E9_ Pirard <PIRARD@vm1.ulg.ac.be>?= 
```

which causes following in mail clients:

![unknown](https://user-images.githubusercontent.com/1900106/83126239-d67b3400-a0d8-11ea-9670-5f1d865537ce.png)
![image](https://user-images.githubusercontent.com/1900106/83126190-c6fbeb00-a0d8-11ea-84cb-07946784def6.png)

https://tools.ietf.org/html/rfc1342