### PR TITLE
Support for inline attachments with NewEmailFromReader

### DIFF
--- a/email.go
+++ b/email.go
@@ -160,8 +160,9 @@ func NewEmailFromReader(r io.Reader) (*Email, error) {
 			if err != nil {
 				return e, err
 			}
-			if cd == "attachment" || cd == "inline" {
-				_, err = e.Attach(bytes.NewReader(p.body), params["filename"], ct)
+			filename, filenameDefined := params["filename"]
+			if cd == "attachment" || (cd == "inline" && filenameDefined){
+				_, err = e.Attach(bytes.NewReader(p.body), filename, ct)
 				if err != nil {
 					return e, err
 				}

--- a/email.go
+++ b/email.go
@@ -160,7 +160,7 @@ func NewEmailFromReader(r io.Reader) (*Email, error) {
 			if err != nil {
 				return e, err
 			}
-			if cd == "attachment" {
+			if cd == "attachment" || cd == "inline" {
 				_, err = e.Attach(bytes.NewReader(p.body), params["filename"], ct)
 				if err != nil {
 					return e, err

--- a/email_test.go
+++ b/email_test.go
@@ -528,7 +528,7 @@ d-printable decoding.</div>
 	}
 }
 
-func TestAttachmentEmailFromReader (t *testing.T) {
+func TestAttachmentEmailFromReader(t *testing.T) {
 	ex := &Email{
 		Subject: "Test Subject",
 		To:      []string{"Jordan Wright <jmwright798@gmail.com>"},
@@ -539,6 +539,10 @@ func TestAttachmentEmailFromReader (t *testing.T) {
 	a, err := ex.Attach(bytes.NewReader([]byte("Let's just pretend this is raw JPEG data.")), "cat.jpeg", "image/jpeg")
 	if err != nil {
 		t.Fatalf("Error attaching image %s", err.Error())
+	}
+	b, err := ex.Attach(bytes.NewReader([]byte("Let's just pretend this is raw JPEG data.")), "cat-inline.jpeg", "image/jpeg")
+	if err != nil {
+		t.Fatalf("Error attaching inline image %s", err.Error())
 	}
 	raw := []byte(`
 From: Jordan Wright <jmwright798@gmail.com>
@@ -575,6 +579,15 @@ Content-Type: image/jpeg
 
 TGV0J3MganVzdCBwcmV0ZW5kIHRoaXMgaXMgcmF3IEpQRUcgZGF0YS4=
 
+--35d10c2224bd787fe700c2c6f4769ddc936eb8a0b58e9c8717e406c5abb7
+Content-Disposition: inline;
+ filename="cat-inline.jpeg"
+Content-Id: <cat-inline.jpeg>
+Content-Transfer-Encoding: base64
+Content-Type: image/jpeg
+
+TGV0J3MganVzdCBwcmV0ZW5kIHRoaXMgaXMgcmF3IEpQRUcgZGF0YS4=
+
 --35d10c2224bd787fe700c2c6f4769ddc936eb8a0b58e9c8717e406c5abb7--`)
 	e, err := NewEmailFromReader(bytes.NewReader(raw))
 	if err != nil {
@@ -592,7 +605,7 @@ TGV0J3MganVzdCBwcmV0ZW5kIHRoaXMgaXMgcmF3IEpQRUcgZGF0YS4=
 	if e.From != ex.From {
 		t.Fatalf("Incorrect \"From\": %#q != %#q", e.From, ex.From)
 	}
-	if len(e.Attachments) != 1  {
+	if len(e.Attachments) != 2 {
 		t.Fatalf("Incorrect number of attachments %d != %d", len(e.Attachments), 1)
 	}
 	if e.Attachments[0].Filename != a.Filename {
@@ -600,6 +613,12 @@ TGV0J3MganVzdCBwcmV0ZW5kIHRoaXMgaXMgcmF3IEpQRUcgZGF0YS4=
 	}
 	if !bytes.Equal(e.Attachments[0].Content, a.Content) {
 		t.Fatalf("Incorrect attachment content %#q != %#q", e.Attachments[0].Content, a.Content)
+	}
+	if e.Attachments[1].Filename != b.Filename {
+		t.Fatalf("Incorrect attachment filename %s != %s", e.Attachments[1].Filename, b.Filename)
+	}
+	if !bytes.Equal(e.Attachments[1].Content, b.Content) {
+		t.Fatalf("Incorrect attachment content %#q != %#q", e.Attachments[1].Content, b.Content)
 	}
 }
 


### PR DESCRIPTION
in v4.0.0 when using NewEmailFromReader to create an email, attachments are only created if Content-Disposition is 'attachment'. This PR adds support for inline attachments as well.

Links to issue #82 just like PR #89 

The failing test during build was there before this change already, assumed it is a known issue