### PR TITLE
Adjusting trimReader to only trim whitespace on the first read.

### DIFF
--- a/email_test.go
+++ b/email_test.go
@@ -94,7 +94,7 @@ func TestEmailWithHTMLAttachments(t *testing.T) {
 	//fmt.Println(string(b))
 
 	// TODO: Verify the attachments.
-	s := trimReader{rd: bytes.NewBuffer(b)}
+	s := &trimReader{rd: bytes.NewBuffer(b)}
 	tp := textproto.NewReader(bufio.NewReader(s))
 	// Parse the main headers
 	hdrs, err := tp.ReadMIMEHeader()
@@ -528,7 +528,7 @@ d-printable decoding.</div>
 	}
 }
 
-func TestAttachmentEmailFromReader (t *testing.T) {
+func TestAttachmentEmailFromReader(t *testing.T) {
 	ex := &Email{
 		Subject: "Test Subject",
 		To:      []string{"Jordan Wright <jmwright798@gmail.com>"},
@@ -592,7 +592,7 @@ TGV0J3MganVzdCBwcmV0ZW5kIHRoaXMgaXMgcmF3IEpQRUcgZGF0YS4=
 	if e.From != ex.From {
 		t.Fatalf("Incorrect \"From\": %#q != %#q", e.From, ex.From)
 	}
-	if len(e.Attachments) != 1  {
+	if len(e.Attachments) != 1 {
 		t.Fatalf("Incorrect number of attachments %d != %d", len(e.Attachments), 1)
 	}
 	if e.Attachments[0].Filename != a.Filename {


### PR DESCRIPTION
To make email parsing via `NewEmailFromReader` more resilient, we wrap the provided reader in a `trimReader`, which is a little custom reader that tries to trim leading whitespace. However, there was a bug where it tried to delete whitespace on _every_ read, not just the first one.

In very rare cases, this would cause email parsing to fail since the next set of bytes to be read would include the `\n` part of a `\r\n`. This PR fixes this by ensuring that leading whitespace is only removed during the first read.

Fixes #106