### PR TITLE
Support for multiple To, Cc, Bcc addresses with NewEmailFromReader

### DIFF
--- a/email.go
+++ b/email.go
@@ -108,32 +108,41 @@ func NewEmailFromReader(r io.Reader) (*Email, error) {
 			}
 			delete(hdrs, h)
 		case h == "To":
-			for _, to := range v {
-				tt, err := (&mime.WordDecoder{}).DecodeHeader(to)
-				if err == nil {
-					e.To = append(e.To, tt)
-				} else {
-					e.To = append(e.To, to)
+			for _, toA := range v {
+				w := strings.Split(toA, ",")
+				for _, to := range w {
+					tt, err := (&mime.WordDecoder{}).DecodeHeader(strings.TrimSpace(to))
+					if err == nil {
+						e.To = append(e.To, tt)
+					} else {
+						e.To = append(e.To, to)
+					}
 				}
 			}
 			delete(hdrs, h)
 		case h == "Cc":
-			for _, cc := range v {
-				tcc, err := (&mime.WordDecoder{}).DecodeHeader(cc)
-				if err == nil {
-					e.Cc = append(e.Cc, tcc)
-				} else {
-					e.Cc = append(e.Cc, cc)
+			for _, ccA := range v {
+				w := strings.Split(ccA, ",")
+				for _, cc := range w {
+					tcc, err := (&mime.WordDecoder{}).DecodeHeader(strings.TrimSpace(cc))
+					if err == nil {
+						e.Cc = append(e.Cc, tcc)
+					} else {
+						e.Cc = append(e.Cc, cc)
+					}
 				}
 			}
 			delete(hdrs, h)
 		case h == "Bcc":
-			for _, bcc := range v {
-				tbcc, err := (&mime.WordDecoder{}).DecodeHeader(bcc)
-				if err == nil {
-					e.Bcc = append(e.Bcc, tbcc)
-				} else {
-					e.Bcc = append(e.Bcc, bcc)
+			for _, bccA := range v {
+				w := strings.Split(bccA, ",")
+				for _, bcc := range w {
+					tbcc, err := (&mime.WordDecoder{}).DecodeHeader(strings.TrimSpace(bcc))
+					if err == nil {
+						e.Bcc = append(e.Bcc, tbcc)
+					} else {
+						e.Bcc = append(e.Bcc, bcc)
+					}
 				}
 			}
 			delete(hdrs, h)

--- a/email_test.go
+++ b/email_test.go
@@ -367,8 +367,10 @@ func TestHeaderEncoding(t *testing.T) {
 func TestEmailFromReader(t *testing.T) {
 	ex := &Email{
 		Subject: "Test Subject",
-		To:      []string{"Jordan Wright <jmwright798@gmail.com>"},
+		To:      []string{"Jordan Wright <jmwright798@gmail.com>", "also@example.com"},
 		From:    "Jordan Wright <jmwright798@gmail.com>",
+		Cc:      []string{"one@example.com", "Two <two@example.com>"},
+		Bcc:     []string{"three@example.com", "Four <four@example.com>"},
 		Text:    []byte("This is a test email with HTML Formatting. It also has very long lines so\nthat the content must be wrapped if using quoted-printable decoding.\n"),
 		HTML:    []byte("<div dir=\"ltr\">This is a test email with <b>HTML Formatting.</b>\u00a0It also has very long lines so that the content must be wrapped if using quoted-printable decoding.</div>\n"),
 	}
@@ -376,7 +378,9 @@ func TestEmailFromReader(t *testing.T) {
 	MIME-Version: 1.0
 Subject: Test Subject
 From: Jordan Wright <jmwright798@gmail.com>
-To: Jordan Wright <jmwright798@gmail.com>
+To: Jordan Wright <jmwright798@gmail.com>, also@example.com
+Cc: one@example.com, Two <two@example.com>
+Bcc: three@example.com, Four <four@example.com>
 Content-Type: multipart/alternative; boundary=001a114fb3fc42fd6b051f834280
 
 --001a114fb3fc42fd6b051f834280
@@ -410,7 +414,33 @@ d-printable decoding.</div>
 	if e.From != ex.From {
 		t.Fatalf("Incorrect \"From\": %#q != %#q", e.From, ex.From)
 	}
-
+	if len(e.To) != len(ex.To) {
+		t.Fatalf("Incorrect number of \"To\" addresses: %v != %v", len(e.To), len(ex.To))
+	}
+	if e.To[0] != ex.To[0] {
+		t.Fatalf("Incorrect \"To[0]\": %#q != %#q", e.To[0], ex.To[0])
+	}
+	if e.To[1] != ex.To[1] {
+		t.Fatalf("Incorrect \"To[1]\": %#q != %#q", e.To[1], ex.To[1])
+	}
+	if len(e.Cc) != len(ex.Cc) {
+		t.Fatalf("Incorrect number of \"Cc\" addresses: %v != %v", len(e.Cc), len(ex.Cc))
+	}
+	if e.Cc[0] != ex.Cc[0] {
+		t.Fatalf("Incorrect \"Cc[0]\": %#q != %#q", e.Cc[0], ex.Cc[0])
+	}
+	if e.Cc[1] != ex.Cc[1] {
+		t.Fatalf("Incorrect \"Cc[1]\": %#q != %#q", e.Cc[1], ex.Cc[1])
+	}
+	if len(e.Bcc) != len(ex.Bcc) {
+		t.Fatalf("Incorrect number of \"Bcc\" addresses: %v != %v", len(e.Bcc), len(ex.Bcc))
+	}
+	if e.Bcc[0] != ex.Bcc[0] {
+		t.Fatalf("Incorrect \"Bcc[0]\": %#q != %#q", e.Cc[0], ex.Cc[0])
+	}
+	if e.Bcc[1] != ex.Bcc[1] {
+		t.Fatalf("Incorrect \"Bcc[1]\": %#q != %#q", e.Bcc[1], ex.Bcc[1])
+	}
 }
 
 func TestNonAsciiEmailFromReader(t *testing.T) {


### PR DESCRIPTION
In the current version NewEmailFromReader is not handling multiple To, Cc and Bcc addresses as expected. 

Eg. 
    For header: `To: Jordan Wright <jmwright798@gmail.com>, also@example.com`
    The API would return `["Jordan Wright <jmwright798@gmail.com>, also@example.com"]` instead of the expected `["Jordan Wright <jmwright798@gmail.com>", "also@example.com"]`

This PR adds support for multiple addresses in the To, Cc and Bcc headers so that in case of a comma separated list of addresses, they would be parsed correctly into multiple entries.

I have also created https://github.com/jordan-wright/email/issues/125 for tracking this issue