### PR TITLE
Enable customization of localName for clients

### DIFF
--- a/email_test.go
+++ b/email_test.go
@@ -2,12 +2,14 @@ package email
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"testing"
 
 	"bufio"
 	"bytes"
 	"crypto/rand"
+	"crypto/tls"
 	"io"
 	"io/ioutil"
 	"mime"
@@ -441,6 +443,7 @@ d-printable decoding.</div>
 	if e.Bcc[1] != ex.Bcc[1] {
 		t.Fatalf("Incorrect \"Bcc[1]\": %#q != %#q", e.Bcc[1], ex.Bcc[1])
 	}
+
 }
 
 func TestNonAsciiEmailFromReader(t *testing.T) {
@@ -653,15 +656,51 @@ TGV0J3MganVzdCBwcmV0ZW5kIHRoaXMgaXMgcmF3IEpQRUcgZGF0YS4=
 }
 
 func ExampleGmail() {
+	gmUser := "test@gmail.com"
+	gmPass := "<password>"
+	gmHost := "smtp.gmail.com"
+	gmPort := "587"
+
 	e := NewEmail()
-	e.From = "Jordan Wright <test@gmail.com>"
+	e.From = "Jordan Wright <" + gmUser + ">"
 	e.To = []string{"test@example.com"}
 	e.Bcc = []string{"test_bcc@example.com"}
 	e.Cc = []string{"test_cc@example.com"}
 	e.Subject = "Awesome Subject"
 	e.Text = []byte("Text Body is, of course, supported!\n")
 	e.HTML = []byte("<h1>Fancy Html is supported, too!</h1>\n")
-	e.Send("smtp.gmail.com:587", smtp.PlainAuth("", e.From, "password123", "smtp.gmail.com"))
+	e.LocalName = "localhost"
+	err := e.Send(
+		gmHost+":"+gmPort,
+		smtp.PlainAuth("", gmUser, gmPass, gmHost),
+	)
+	if err != nil {
+		log.Fatalf("Failed to send gmail mail: %v", err)
+	}
+}
+
+func ExampleGmailWithTLS() {
+	gmUser := "test@gmail.com"
+	gmPass := "<password>"
+	gmHost := "smtp.gmail.com"
+	gmPort := "465"
+
+	e := NewEmail()
+	e.From = "Jordan Wright <" + gmUser + ">"
+	e.To = []string{"test@example.com"}
+	e.Bcc = []string{"test_bcc@example.com"}
+	e.Cc = []string{"test_cc@example.com"}
+	e.Subject = "Awesome Subject"
+	e.Text = []byte("Text Body is, of course, supported!\n")
+	e.HTML = []byte("<h1>Fancy Html is supported, too!</h1>\n")
+	e.LocalName = "localhost"
+	err := e.SendWithTLS(
+		gmHost+":"+gmPort,
+		smtp.PlainAuth("", gmUser, gmPass, gmHost),
+		&tls.Config{ServerName: gmHost})
+	if err != nil {
+		log.Fatalf("Failed to send gmail mail: %v", err)
+	}
 }
 
 func ExampleAttach() {


### PR DESCRIPTION
This change enables custom LocalName entries to be specified for sending emails.

The motive is that smtp-relay.gmail.com heavily throttles the number of emails that are accepted with a LocalName of "localhost". To get past the ehlo step in this case the connection must specify another LocalName.

The smtp library has "localhost" hardcoded, so this change also changes the Send(...) implementation to inline the smtp.SendMail(...) call, modifying the Hello step.