### PR TITLE
Support for MIME headers when using NewEmailFromReader

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    env:
+      GO111MODULE: auto
     steps:
 
     - name: Set up Go 1.x

--- a/email.go
+++ b/email.go
@@ -167,7 +167,7 @@ func NewEmailFromReader(r io.Reader) (*Email, error) {
 			}
 			filename, filenameDefined := params["filename"]
 			if cd == "attachment" || (cd == "inline" && filenameDefined) {
-				_, err = e.Attach(bytes.NewReader(p.body), filename, ct)
+				_, err = e.AttachWithHeaders(bytes.NewReader(p.body), filename, ct, p.header)
 				if err != nil {
 					return e, err
 				}
@@ -262,6 +262,13 @@ func parseMIMEParts(hs textproto.MIMEHeader, b io.Reader) ([]*part, error) {
 // Required parameters include an io.Reader, the desired filename for the attachment, and the Content-Type
 // The function will return the created Attachment for reference, as well as nil for the error, if successful.
 func (e *Email) Attach(r io.Reader, filename string, c string) (a *Attachment, err error) {
+	return e.AttachWithHeaders(r, filename, c, textproto.MIMEHeader{})
+}
+
+// AttachWithHeaders is used to attach content from an io.Reader to the email. Required parameters include an io.Reader,
+// the desired filename for the attachment, the Content-Type and the original MIME headers.
+// The function will return the created Attachment for reference, as well as nil for the error, if successful.
+func (e *Email) AttachWithHeaders(r io.Reader, filename string, c string, headers textproto.MIMEHeader) (a *Attachment, err error) {
 	var buffer bytes.Buffer
 	if _, err = io.Copy(&buffer, r); err != nil {
 		return
@@ -269,7 +276,7 @@ func (e *Email) Attach(r io.Reader, filename string, c string) (a *Attachment, e
 	at := &Attachment{
 		Filename:    filename,
 		ContentType: c,
-		Header:      textproto.MIMEHeader{},
+		Header:      headers,
 		Content:     buffer.Bytes(),
 	}
 	e.Attachments = append(e.Attachments, at)

--- a/email.go
+++ b/email.go
@@ -763,7 +763,7 @@ func headerToBytes(buff io.Writer, header textproto.MIMEHeader) {
 			switch {
 			case field == "Content-Type" || field == "Content-Disposition":
 				buff.Write([]byte(subval))
-			case field == "From" || field == "To" || field == "Cc" || field == "Bcc":
+			case field == "From" || field == "To" || field == "Cc" || field == "Bcc" || field == "Reply-To":
 				participants := strings.Split(subval, ",")
 				for i, v := range participants {
 					addr, err := mail.ParseAddress(v)

--- a/email.go
+++ b/email.go
@@ -160,8 +160,9 @@ func NewEmailFromReader(r io.Reader) (*Email, error) {
 			if err != nil {
 				return e, err
 			}
-			if cd == "attachment" || cd == "inline" {
-				_, err = e.Attach(bytes.NewReader(p.body), params["filename"], ct)
+			filename, filenameDefined := params["filename"]
+			if cd == "attachment" || (cd == "inline" && filenameDefined){
+				_, err = e.Attach(bytes.NewReader(p.body), filename, ct)
 				if err != nil {
 					return e, err
 				}

--- a/email.go
+++ b/email.go
@@ -165,8 +165,8 @@ func NewEmailFromReader(r io.Reader) (*Email, error) {
 			if err != nil {
 				return e, err
 			}
-			filename, filenameDefined := params["filename"]
-			if cd == "attachment" || (cd == "inline" && filenameDefined) {
+			filename, _ := params["filename"]
+			if cd == "attachment" || (cd == "inline" && p.header.Get("Content-ID") != "") {
 				_, err = e.AttachWithHeaders(bytes.NewReader(p.body), filename, ct, p.header)
 				if err != nil {
 					return e, err
@@ -721,11 +721,11 @@ func (at *Attachment) setDefaultHeaders() {
 	at.Header.Set("Content-Type", contentType)
 
 	if len(at.Header.Get("Content-Disposition")) == 0 {
-		disposition := "attachment"
 		if at.HTMLRelated {
-			disposition = "inline"
+			at.Header.Set("Content-Disposition", "inline")
+		}else{
+			at.Header.Set("Content-Disposition", fmt.Sprintf("%s;\r\n filename=\"%s\"", "attachment", at.Filename))
 		}
-		at.Header.Set("Content-Disposition", fmt.Sprintf("%s;\r\n filename=\"%s\"", disposition, at.Filename))
 	}
 	if len(at.Header.Get("Content-ID")) == 0 {
 		at.Header.Set("Content-ID", fmt.Sprintf("<%s>", at.Filename))

--- a/email.go
+++ b/email.go
@@ -160,7 +160,7 @@ func NewEmailFromReader(r io.Reader) (*Email, error) {
 			if err != nil {
 				return e, err
 			}
-			if cd == "attachment" {
+			if cd == "attachment" || cd == "inline" {
 				_, err = e.Attach(bytes.NewReader(p.body), params["filename"], ct)
 				if err != nil {
 					return e, err

--- a/email.go
+++ b/email.go
@@ -108,32 +108,41 @@ func NewEmailFromReader(r io.Reader) (*Email, error) {
 			}
 			delete(hdrs, h)
 		case h == "To":
-			for _, to := range v {
-				tt, err := (&mime.WordDecoder{}).DecodeHeader(to)
-				if err == nil {
-					e.To = append(e.To, tt)
-				} else {
-					e.To = append(e.To, to)
+			for _, toA := range v {
+				w := strings.Split(toA, ",")
+				for _, to := range w {
+					tt, err := (&mime.WordDecoder{}).DecodeHeader(strings.TrimSpace(to))
+					if err == nil {
+						e.To = append(e.To, tt)
+					} else {
+						e.To = append(e.To, to)
+					}
 				}
 			}
 			delete(hdrs, h)
 		case h == "Cc":
-			for _, cc := range v {
-				tcc, err := (&mime.WordDecoder{}).DecodeHeader(cc)
-				if err == nil {
-					e.Cc = append(e.Cc, tcc)
-				} else {
-					e.Cc = append(e.Cc, cc)
+			for _, ccA := range v {
+				w := strings.Split(ccA, ",")
+				for _, cc := range w {
+					tcc, err := (&mime.WordDecoder{}).DecodeHeader(strings.TrimSpace(cc))
+					if err == nil {
+						e.Cc = append(e.Cc, tcc)
+					} else {
+						e.Cc = append(e.Cc, cc)
+					}
 				}
 			}
 			delete(hdrs, h)
 		case h == "Bcc":
-			for _, bcc := range v {
-				tbcc, err := (&mime.WordDecoder{}).DecodeHeader(bcc)
-				if err == nil {
-					e.Bcc = append(e.Bcc, tbcc)
-				} else {
-					e.Bcc = append(e.Bcc, bcc)
+			for _, bccA := range v {
+				w := strings.Split(bccA, ",")
+				for _, bcc := range w {
+					tbcc, err := (&mime.WordDecoder{}).DecodeHeader(strings.TrimSpace(bcc))
+					if err == nil {
+						e.Bcc = append(e.Bcc, tbcc)
+					} else {
+						e.Bcc = append(e.Bcc, bcc)
+					}
 				}
 			}
 			delete(hdrs, h)

--- a/email_test.go
+++ b/email_test.go
@@ -398,6 +398,11 @@ func TestHeaderEncoding(t *testing.T) {
 			want:  "=?utf-8?q?Needs_Enc=C3=B3ding?= <encoding@example.com>, \"Only ASCII\" <foo@example.com>\r\n",
 		},
 		{
+			field: "Reply-To",
+			have:  "Needs Encóding <encoding@example.com>, Only ASCII <foo@example.com>",
+			want:  "=?utf-8?q?Needs_Enc=C3=B3ding?= <encoding@example.com>, \"Only ASCII\" <foo@example.com>\r\n",
+		},
+		{
 			field: "To",
 			have:  "Keith Moore <moore@cs.utk.edu>, Keld Jørn Simonsen <keld@dkuug.dk>",
 			want:  "\"Keith Moore\" <moore@cs.utk.edu>, =?utf-8?q?Keld_J=C3=B8rn_Simonsen?= <keld@dkuug.dk>\r\n",
@@ -523,6 +528,7 @@ func TestNonAsciiEmailFromReader(t *testing.T) {
 	ex := &Email{
 		Subject: "Test Subject",
 		To:      []string{"Anaïs <anais@example.org>"},
+		ReplyTo: []string{"Anaïs <anais@example.org>"},
 		Cc:      []string{"Patrik Fältström <paf@example.com>"},
 		From:    "Mrs ValÃ©rie Dupont <valerie.dupont@example.com>",
 		Text:    []byte("This is a test message!"),
@@ -532,6 +538,7 @@ func TestNonAsciiEmailFromReader(t *testing.T) {
 Subject: =?UTF-8?Q?Test Subject?=
 From: Mrs =?ISO-8859-1?Q?Val=C3=A9rie=20Dupont?= <valerie.dupont@example.com>
 To: =?utf-8?q?Ana=C3=AFs?= <anais@example.org>
+Reply-To: =?utf-8?q?Ana=C3=AFs?= <anais@example.org>
 Cc: =?ISO-8859-1?Q?Patrik_F=E4ltstr=F6m?= <paf@example.com>
 Content-type: text/plain; charset=ISO-8859-1
 
@@ -548,6 +555,9 @@ This is a test message!`)
 	}
 	if e.To[0] != ex.To[0] {
 		t.Fatalf("Incorrect \"To\": %#q != %#q", e.To, ex.To)
+	}
+	if e.ReplyTo[0] != ex.ReplyTo[0] {
+		t.Fatalf("Incorrect \"Reply-To\": %#q != %#q", e.ReplyTo, ex.ReplyTo)
 	}
 	if e.Cc[0] != ex.Cc[0] {
 		t.Fatalf("Incorrect \"Cc\": %#q != %#q", e.Cc, ex.Cc)

--- a/email_test.go
+++ b/email_test.go
@@ -679,7 +679,7 @@ Content-Type: text/html; charset=UTF-8
 --35d10c2224bd787fe700c2c6f4769ddc936eb8a0b58e9c8717e406c5abb7
 Content-Disposition: attachment;
  filename="cat.jpeg"
-Content-Id: <cat.jpeg>
+Content-Id: <cat.content-id>
 Content-Transfer-Encoding: base64
 Content-Type: image/jpeg
 
@@ -688,7 +688,7 @@ TGV0J3MganVzdCBwcmV0ZW5kIHRoaXMgaXMgcmF3IEpQRUcgZGF0YS4=
 --35d10c2224bd787fe700c2c6f4769ddc936eb8a0b58e9c8717e406c5abb7
 Content-Disposition: inline;
  filename="cat-inline.jpeg"
-Content-Id: <cat-inline.jpeg>
+Content-Id: <cat-inline.content-id>
 Content-Transfer-Encoding: base64
 Content-Type: image/jpeg
 
@@ -720,11 +720,21 @@ TGV0J3MganVzdCBwcmV0ZW5kIHRoaXMgaXMgcmF3IEpQRUcgZGF0YS4=
 	if !bytes.Equal(e.Attachments[0].Content, a.Content) {
 		t.Fatalf("Incorrect attachment content %#q != %#q", e.Attachments[0].Content, a.Content)
 	}
+	if e.Attachments[0].Header != nil {
+		if e.Attachments[0].Header.Get("Content-Id") != "<cat.content-id>" {
+			t.Fatalf("Incorrect attachment header Content-Id %s != %s", e.Attachments[0].Header.Get("Content-Id"), "<cat.content-id>")
+		}
+	}
 	if e.Attachments[1].Filename != b.Filename {
 		t.Fatalf("Incorrect attachment filename %s != %s", e.Attachments[1].Filename, b.Filename)
 	}
 	if !bytes.Equal(e.Attachments[1].Content, b.Content) {
 		t.Fatalf("Incorrect attachment content %#q != %#q", e.Attachments[1].Content, b.Content)
+	}
+	if e.Attachments[1].Header != nil {
+		if e.Attachments[1].Header.Get("Content-Id") != "<cat-inline.content-id>" {
+			t.Fatalf("Incorrect attachment header Content-Id %s != %s", e.Attachments[1].Header.Get("Content-Id"), "<cat-inline.content-id>")
+		}
 	}
 }
 

--- a/email_test.go
+++ b/email_test.go
@@ -85,6 +85,12 @@ func TestEmailWithHTMLAttachments(t *testing.T) {
 	}
 	attachment.HTMLRelated = true
 
+	// Set regular HTML attachment.
+	_, err = e.Attach(bytes.NewBufferString("Normal attachment"), "normal.pdf", "application/pdf; charset=utf-8")
+	if err != nil {
+		t.Fatal("Could not add an attachment to the message: ", err)
+	}
+
 	b, err := e.Bytes()
 	if err != nil {
 		t.Fatal("Could not serialize e-mail:", err)
@@ -110,14 +116,17 @@ func TestEmailWithHTMLAttachments(t *testing.T) {
 	plainTextFound := false
 	htmlFound := false
 	imageFound := false
-	if expected, actual := 3, len(ps); actual != expected {
+	if expected, actual := 4, len(ps); actual != expected {
 		t.Error("Unexpected number of parts. Expected:", expected, "Was:", actual)
 	}
 	for _, part := range ps {
 		// part has "header" and "body []byte"
 		cd := part.header.Get("Content-Disposition")
 		ct := part.header.Get("Content-Type")
-		if strings.Contains(ct, "image/png") && strings.HasPrefix(cd, "inline") {
+		if strings.Contains(ct, "image/png") && strings.HasPrefix(cd, "inline") && !strings.Contains(cd, "rad.txt"){
+			imageFound = true
+		}
+		if strings.Contains(ct, "application/pdf") && strings.HasPrefix(cd, "attachment") && strings.Contains(cd, "normal.pdf"){
 			imageFound = true
 		}
 		if strings.Contains(ct, "text/html") {
@@ -650,6 +659,11 @@ func TestAttachmentEmailFromReader(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error attaching inline image %s", err.Error())
 	}
+	c, err := ex.Attach(bytes.NewReader([]byte("Let's just pretend this is raw JPEG data.")), "html-related-cat.jpeg", "image/jpeg")
+	if err != nil {
+		t.Fatalf("Error attaching html-related inline image %s", err.Error())
+	}
+	b.HTMLRelated = true
 	raw := []byte(`
 From: Jordan Wright <jmwright798@gmail.com>
 Date: Thu, 17 Oct 2019 08:55:37 +0100
@@ -694,6 +708,14 @@ Content-Type: image/jpeg
 
 TGV0J3MganVzdCBwcmV0ZW5kIHRoaXMgaXMgcmF3IEpQRUcgZGF0YS4=
 
+--35d10c2224bd787fe700c2c6f4769ddc936eb8a0b58e9c8717e406c5abb7
+Content-Disposition: inline
+Content-Id: <html-related-cat.content-id>
+Content-Transfer-Encoding: base64
+Content-Type: image/jpeg
+
+TGV0J3MganVzdCBwcmV0ZW5kIHRoaXMgaXMgcmF3IEpQRUcgZGF0YS4=
+
 --35d10c2224bd787fe700c2c6f4769ddc936eb8a0b58e9c8717e406c5abb7--`)
 	e, err := NewEmailFromReader(bytes.NewReader(raw))
 	if err != nil {
@@ -711,8 +733,8 @@ TGV0J3MganVzdCBwcmV0ZW5kIHRoaXMgaXMgcmF3IEpQRUcgZGF0YS4=
 	if e.From != ex.From {
 		t.Fatalf("Incorrect \"From\": %#q != %#q", e.From, ex.From)
 	}
-	if len(e.Attachments) != 2 {
-		t.Fatalf("Incorrect number of attachments %d != %d", len(e.Attachments), 1)
+	if len(e.Attachments) != 3 {
+		t.Fatalf("Incorrect number of attachments %d != %d", len(e.Attachments), 3)
 	}
 	if e.Attachments[0].Filename != a.Filename {
 		t.Fatalf("Incorrect attachment filename %s != %s", e.Attachments[0].Filename, a.Filename)
@@ -734,6 +756,18 @@ TGV0J3MganVzdCBwcmV0ZW5kIHRoaXMgaXMgcmF3IEpQRUcgZGF0YS4=
 	if e.Attachments[1].Header != nil {
 		if e.Attachments[1].Header.Get("Content-Id") != "<cat-inline.content-id>" {
 			t.Fatalf("Incorrect attachment header Content-Id %s != %s", e.Attachments[1].Header.Get("Content-Id"), "<cat-inline.content-id>")
+		}
+	}
+	//Filename should be empty as we are using html-related and inline attachment
+	if e.Attachments[2].Filename != "" {
+		t.Fatalf("Incorrect attachment filename %s != %s", e.Attachments[2].Filename, "")
+	}
+	if !bytes.Equal(e.Attachments[2].Content, c.Content) {
+		t.Fatalf("Incorrect attachment content %#q != %#q", e.Attachments[2].Content, c.Content)
+	}
+	if e.Attachments[2].Header != nil {
+		if e.Attachments[2].Header.Get("Content-Id") != "<html-related-cat.content-id>" {
+			t.Fatalf("Incorrect attachment header Content-Id %s != %s", e.Attachments[2].Header.Get("Content-Id"), "<html-related-cat.content-id>")
 		}
 	}
 }

--- a/email_test.go
+++ b/email_test.go
@@ -528,7 +528,7 @@ d-printable decoding.</div>
 	}
 }
 
-func TestAttachmentEmailFromReader (t *testing.T) {
+func TestAttachmentEmailFromReader(t *testing.T) {
 	ex := &Email{
 		Subject: "Test Subject",
 		To:      []string{"Jordan Wright <jmwright798@gmail.com>"},
@@ -539,6 +539,10 @@ func TestAttachmentEmailFromReader (t *testing.T) {
 	a, err := ex.Attach(bytes.NewReader([]byte("Let's just pretend this is raw JPEG data.")), "cat.jpeg", "image/jpeg")
 	if err != nil {
 		t.Fatalf("Error attaching image %s", err.Error())
+	}
+	b, err := ex.Attach(bytes.NewReader([]byte("Let's just pretend this is raw JPEG data.")), "cat-inline.jpeg", "image/jpeg")
+	if err != nil {
+		t.Fatalf("Error attaching inline image %s", err.Error())
 	}
 	raw := []byte(`
 From: Jordan Wright <jmwright798@gmail.com>
@@ -575,6 +579,15 @@ Content-Type: image/jpeg
 
 TGV0J3MganVzdCBwcmV0ZW5kIHRoaXMgaXMgcmF3IEpQRUcgZGF0YS4=
 
+--35d10c2224bd787fe700c2c6f4769ddc936eb8a0b58e9c8717e406c5abb7
+Content-Disposition: inline;
+ filename="cat-inline.jpeg"
+Content-Id: <cat-inline.jpeg>
+Content-Transfer-Encoding: base64
+Content-Type: image/jpeg
+
+TGV0J3MganVzdCBwcmV0ZW5kIHRoaXMgaXMgcmF3IEpQRUcgZGF0YS4=
+
 --35d10c2224bd787fe700c2c6f4769ddc936eb8a0b58e9c8717e406c5abb7--`)
 	e, err := NewEmailFromReader(bytes.NewReader(raw))
 	if err != nil {
@@ -592,7 +605,7 @@ TGV0J3MganVzdCBwcmV0ZW5kIHRoaXMgaXMgcmF3IEpQRUcgZGF0YS4=
 	if e.From != ex.From {
 		t.Fatalf("Incorrect \"From\": %#q != %#q", e.From, ex.From)
 	}
-	if len(e.Attachments) != 1  {
+	if len(e.Attachments) != 2 {
 		t.Fatalf("Incorrect number of attachments %d != %d", len(e.Attachments), 1)
 	}
 	if e.Attachments[0].Filename != a.Filename {
@@ -600,6 +613,12 @@ TGV0J3MganVzdCBwcmV0ZW5kIHRoaXMgaXMgcmF3IEpQRUcgZGF0YS4=
 	}
 	if !bytes.Equal(e.Attachments[0].Content, a.Content) {
 		t.Fatalf("Incorrect attachment content %#q != %#q", e.Attachments[0].Content, a.Content)
+	}
+	if e.Attachments[1].Filename != b.Filename {
+		t.Fatalf("Incorrect attachment filename %s != %s", e.Attachments[1].Filename, b.Filename)
+	}
+	if !bytes.Equal(e.Attachments[1].Content, b.Content) {
+		t.Fatalf("Incorrect attachment content %#q != %#q", e.Attachments[1].Content, b.Content)
 	}
 }
 

--- a/email_test.go
+++ b/email_test.go
@@ -367,8 +367,10 @@ func TestHeaderEncoding(t *testing.T) {
 func TestEmailFromReader(t *testing.T) {
 	ex := &Email{
 		Subject: "Test Subject",
-		To:      []string{"Jordan Wright <jmwright798@gmail.com>"},
+		To:      []string{"Jordan Wright <jmwright798@gmail.com>", "also@example.com"},
 		From:    "Jordan Wright <jmwright798@gmail.com>",
+		Cc:      []string{"one@example.com", "Two <two@example.com>"},
+		Bcc:     []string{"three@example.com", "Four <four@example.com>"},
 		Text:    []byte("This is a test email with HTML Formatting. It also has very long lines so\nthat the content must be wrapped if using quoted-printable decoding.\n"),
 		HTML:    []byte("<div dir=\"ltr\">This is a test email with <b>HTML Formatting.</b>\u00a0It also has very long lines so that the content must be wrapped if using quoted-printable decoding.</div>\n"),
 	}
@@ -376,7 +378,9 @@ func TestEmailFromReader(t *testing.T) {
 	MIME-Version: 1.0
 Subject: Test Subject
 From: Jordan Wright <jmwright798@gmail.com>
-To: Jordan Wright <jmwright798@gmail.com>
+To: Jordan Wright <jmwright798@gmail.com>, also@example.com
+Cc: one@example.com, Two <two@example.com>
+Bcc: three@example.com, Four <four@example.com>
 Content-Type: multipart/alternative; boundary=001a114fb3fc42fd6b051f834280
 
 --001a114fb3fc42fd6b051f834280
@@ -410,7 +414,33 @@ d-printable decoding.</div>
 	if e.From != ex.From {
 		t.Fatalf("Incorrect \"From\": %#q != %#q", e.From, ex.From)
 	}
-
+	if len(e.To) != len(ex.To) {
+		t.Fatalf("Incorrect number of \"To\" addresses: %v != %v", len(e.To), len(ex.To))
+	}
+	if e.To[0] != ex.To[0] {
+		t.Fatalf("Incorrect \"To[0]\": %#q != %#q", e.To[0], ex.To[0])
+	}
+	if e.To[1] != ex.To[1] {
+		t.Fatalf("Incorrect \"To[1]\": %#q != %#q", e.To[1], ex.To[1])
+	}
+	if len(e.Cc) != len(ex.Cc) {
+		t.Fatalf("Incorrect number of \"Cc\" addresses: %v != %v", len(e.Cc), len(ex.Cc))
+	}
+	if e.Cc[0] != ex.Cc[0] {
+		t.Fatalf("Incorrect \"Cc[0]\": %#q != %#q", e.Cc[0], ex.Cc[0])
+	}
+	if e.Cc[1] != ex.Cc[1] {
+		t.Fatalf("Incorrect \"Cc[1]\": %#q != %#q", e.Cc[1], ex.Cc[1])
+	}
+	if len(e.Bcc) != len(ex.Bcc) {
+		t.Fatalf("Incorrect number of \"Bcc\" addresses: %v != %v", len(e.Bcc), len(ex.Bcc))
+	}
+	if e.Bcc[0] != ex.Bcc[0] {
+		t.Fatalf("Incorrect \"Bcc[0]\": %#q != %#q", e.Cc[0], ex.Cc[0])
+	}
+	if e.Bcc[1] != ex.Bcc[1] {
+		t.Fatalf("Incorrect \"Bcc[1]\": %#q != %#q", e.Bcc[1], ex.Bcc[1])
+	}
 }
 
 func TestNonAsciiEmailFromReader(t *testing.T) {


### PR DESCRIPTION
This PR resolves #139 - Missing MIME headers with NewEmailFromReader.

The issue once again:

In the latest master version (943e75fe5223047b345337ea74d5951d19d229ed) when e-mails are created with NewEmailFromReader and they contain attachments, the attachments will have empty MIME headers. This is due to commit b84218f6af87ca49ed7465d40545587bd94b379f on Dec 30, 2020 which resolved a different issue. The MIME headers were never covered by a Unit test, so this was not picked up.

The old removed implementation however was also buggy as it set the Content-Id header of the attachment always to the file name. This is incorrect behavior as Content-Id can have a different value and should be read directly from the MIME header.

This PR:

Resolves the issue by attaching the original MIME headers also to the Attachment object. The parsed values will thus be available separately as struct fields but the raw values will be available as well.

In order to maintain API compatibility a new variation of the Attach() function was also created named AttachWithHeaders() which takes an extra argument. It would have been possible to add the headers directly in the NewEmailFromReader() function and skip this new function but I thought it would be better to make it explicit in the API as well that the original function does not add headers. If this new function is too much clutter, I will be happy to amend the PR and add the headers directly in the NewEmailFromReader() function.

Tests have been created to cover the Content-Id header of attachments