### PR TITLE
fix hidden errors

### DIFF
--- a/email.go
+++ b/email.go
@@ -280,10 +280,10 @@ func (e *Email) Attach(r io.Reader, filename string, c string) (a *Attachment, e
 // It attempts to open the file referenced by filename and, if successful, creates an Attachment.
 // This Attachment is then appended to the slice of Email.Attachments.
 // The function will then return the Attachment for reference, as well as nil for the error, if successful.
-func (e *Email) AttachFile(filename string) (a *Attachment, err error) {
+func (e *Email) AttachFile(filename string) (*Attachment, error) {
 	f, err := os.Open(filename)
 	if err != nil {
-		return
+		return nil, err
 	}
 	defer f.Close()
 


### PR DESCRIPTION
Hello,

thank for this neat library! Just stumbled over some swallowed errors. IMHO named returned values are always a little bit dangerous. In your case the returned named error was not set as a new one was defined, i.e.:

```
func foo() (err error) {
  err := barReturningAnErrror()
  if err != nil {
    return
  }
}
```

will not return anything. Hopefully I got all occurrences of the issue.

Best regards

<sub>Mathias Zeller <mathias.zeller@mercedes-benz.com> Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md))
</sub>